### PR TITLE
JCB-25088: Remove chemical logic testing from examples db tests

### DIFF
--- a/src/test/java/search/db/AsyncSearchExampleTest.java
+++ b/src/test/java/search/db/AsyncSearchExampleTest.java
@@ -12,21 +12,21 @@ import com.chemaxon.test.helper.PrintCollector;
 public class AsyncSearchExampleTest {
 
 	private PrintCollector pc = new PrintCollector();
-	
+
 	@Before
 	public void setOutput() {
 		AsyncSearchExample.out=pc.getOutStream();
 	}
-	
+
 	@Test
-	public void finds210Hits() {
+	public void returnsWithResult() {
 		AsyncSearchExample.main(new String[] {});
-		assertThat(pc.getOutputLines(), Matchers.hasItem("210 hit(s) found."));
+		assertThat(pc.getOutputLines(), Matchers.hasItem(Matchers.endsWith(" hit(s) found.")));
 	}
-	
+
 	@After
 	public void resetOutput() {
 		AsyncSearchExample.out=System.out;
 	}
-	
+
 }

--- a/src/test/java/search/db/CalculatedColumnsSearchExampleTest.java
+++ b/src/test/java/search/db/CalculatedColumnsSearchExampleTest.java
@@ -1,7 +1,6 @@
 package search.db;
 
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -20,24 +19,24 @@ public class CalculatedColumnsSearchExampleTest {
 	}
 
 	@Test
-	public void logPHas70Hits() {
+	public void logPReturnsWithResult() {
 		CalculatedColumnsSearchExample.main(new String[] {});
 		assertThat(pc.getOutputLines().get(2), Matchers.is("Results using logp"));
-		assertThat(pc.getOutputLines().get(3), Matchers.is("Hit count: 70"));
+		assertThat(pc.getOutputLines().get(3), Matchers.startsWith("Hit count: "));
 	}
 
 	@Test
-	public void rtblBndCountHas0Hits() {
+	public void rtblBndCountReturnsWithResult() {
 		CalculatedColumnsSearchExample.main(new String[] {});
 		assertThat(pc.getOutputLines().get(6), Matchers.is("Results using rtbl_bnd_cnt"));
-		assertThat(pc.getOutputLines().get(7), Matchers.is("Hit count: 0"));
+		assertThat(pc.getOutputLines().get(7), Matchers.startsWith("Hit count: "));
 	}
 
 	@Test
-	public void pkaAc2HasAtLeast6Hits() {
+	public void pkaAc2ReturnsWithResult() {
 		CalculatedColumnsSearchExample.main(new String[] {});
 		assertThat(pc.getOutputLines().get(10), Matchers.is("Results using pka_ac_2"));
-		assertTrue(Integer.parseInt(pc.getOutputLines().get(11).substring("Hit count: ".length()))>=6);
+		assertThat(pc.getOutputLines().get(11), Matchers.startsWith("Hit count: "));
 	}
 
 	@After

--- a/src/test/java/search/db/ChemicalTermsFilteringExampleTest.java
+++ b/src/test/java/search/db/ChemicalTermsFilteringExampleTest.java
@@ -2,10 +2,8 @@ package search.db;
 
 import static org.junit.Assert.*;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,17 +22,11 @@ public class ChemicalTermsFilteringExampleTest {
 	@Test
 	public void chemicalTermsFilteringTest() {
 		ChemicalTermsFilteringExample.main(null);
-		
-		List<String> outputLines = pc.getOutputLines();
-		assertTrue(getHitAndPkaAboveLimit(outputLines.get(0))>60);
-        assertTrue(getHitAndPkaAboveLimit(outputLines.get(1))>60);
-	}
 
-	private int getHitAndPkaAboveLimit(String string) {
-	    String hitCountStr = 
-	            string.replaceFirst("Search has found ", "").replaceFirst(" hits in which .* has pka value greater than .*", "");
-        return Integer.valueOf( hitCountStr);
-    }
+		List<String> outputLines = pc.getOutputLines();
+		assertTrue(outputLines.get(0).startsWith("Search has found "));
+        assertTrue(outputLines.get(1).startsWith("Search has found "));
+	}
 
     @After
 	public void resetOutputStream() {

--- a/src/test/java/search/db/DatabaseSearchExampleTest.java
+++ b/src/test/java/search/db/DatabaseSearchExampleTest.java
@@ -1,7 +1,7 @@
 package search.db;
 
 import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 import org.junit.After;
 import org.junit.Before;
@@ -12,39 +12,39 @@ import com.chemaxon.test.helper.PrintCollector;
 public class DatabaseSearchExampleTest {
 
 	private PrintCollector pc = new PrintCollector();
-	
+
 	@Before
 	public void changeOutputStream() {
 		DatabaseSearchExample.out=pc.getOutStream();
 	}
-	
+
 	@Test
-	public void searchCCNCCHas111Hits() {
+	public void searchCCNCCReturnsWithResult() {
 		DatabaseSearchExample.main(null);
-		assertThat(pc.getOutputLines().get(1), is("Hit count: 111"));
+		assertThat(pc.getOutputLines().get(1), startsWith("Hit count: "));
 	}
-	
+
 	@Test
-	public void searchCCNPlusCCHas2Hits() {
+	public void searchCCNPlusCCReturnsWithResult() {
 		DatabaseSearchExample.main(null);
-		assertThat(pc.getOutputLines().get(5), is("Hit count: 2"));
+		assertThat(pc.getOutputLines().get(5), startsWith("Hit count: "));
 	}
-	
+
 	@Test
-	public void searchCCNPlusCCWithChargeIgnoreHas111Hits() {
+	public void searchCCNPlusCCWithChargeIgnoreReturnsWithResult() {
 		DatabaseSearchExample.main(null);
-		assertThat(pc.getOutputLines().get(9), is("Hit count: 111"));
+		assertThat(pc.getOutputLines().get(9), startsWith("Hit count: "));
 	}
-	
+
 	@Test
-	public void searchCCNPlusCCWithChargeIgnoreAndForumlaQueryHas68Hits() {
+	public void searchCCNPlusCCWithChargeIgnoreAndForumlaQueryReturnsWithResult() {
 		DatabaseSearchExample.main(null);
-		assertThat(pc.getOutputLines().get(13), is("Hit count: 68"));
+		assertThat(pc.getOutputLines().get(13), startsWith("Hit count: "));
 	}
-	
+
 	@After
 	public void resetOutputStream() {
 		DatabaseSearchExample.out=System.out;
 	}
-	
+
 }

--- a/src/test/java/search/db/DiverseSelectionExampleTest.java
+++ b/src/test/java/search/db/DiverseSelectionExampleTest.java
@@ -25,7 +25,6 @@ public class DiverseSelectionExampleTest {
 	public void diverseSelectTets() {
 		DiverseSelectionExample.main(null);
 		List<String> outputLines = pc.getOutputLines();
-		//System.out.println(outputLines);
 
 		String[] expectedRepresentatives = VersionInfo.getJChemTableVersion() >= 23050000
 				? new String[] { "S(SC1=NC2=C(S1)C=CC=C2)C1=NC2=CC=CC=C2S1", "NC(=O)NNC(=O)NNC(N)=O" }

--- a/src/test/java/search/db/MultipleQueriesExampleTest.java
+++ b/src/test/java/search/db/MultipleQueriesExampleTest.java
@@ -21,7 +21,7 @@ public class MultipleQueriesExampleTest {
 	@Test
 	public void searchWithMultipleQueriesTest() {
 		MultipleQueriesExample.main(null);
-		long queriesRun = pc.getOutputLines().stream().filter("Result count: 52"::equals).count();
+		long queriesRun = pc.getOutputLines().stream().filter(line -> line.contains("Result count: ")).count();
 		assertThat(queriesRun, Matchers.is(2L));
 	}
 

--- a/src/test/java/search/db/ReactionSimilaritySearchExampleTest.java
+++ b/src/test/java/search/db/ReactionSimilaritySearchExampleTest.java
@@ -1,6 +1,6 @@
 package search.db;
 
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 import org.junit.After;
@@ -12,39 +12,39 @@ import com.chemaxon.test.helper.PrintCollector;
 public class ReactionSimilaritySearchExampleTest {
 
 	private PrintCollector pc = new PrintCollector();
-	
+
 	@Before
 	public void changeOutputStream() {
 		ReactionSimilaritySearchExample.out=pc.getOutStream();
 	}
-	
+
 	@Test
-	public void searchReactantTanimotoHas1Hit() {
+	public void searchReactantTanimotoReturnsWithResult() {
 		ReactionSimilaritySearchExample.main(null);
-		assertThat(pc.getOutputLines().get(2), is("Hit count: 1"));
+		assertThat(pc.getOutputLines().get(2), startsWith("Hit count: "));
 	}
-	
+
 	@Test
-	public void searchProductTanimotoHas1Hits() {
+	public void searchProductTanimotoReturnsWithResult() {
 		ReactionSimilaritySearchExample.main(null);
-		assertThat(pc.getOutputLines().get(7), is("Hit count: 1"));
+		assertThat(pc.getOutputLines().get(7), startsWith("Hit count: "));
 	}
-	
+
 	@Test
-	public void searchCoarseReactionTanimotoHas6Hits() {
+	public void searchCoarseReactionTanimotoReturnsWithResult() {
 		ReactionSimilaritySearchExample.main(null);
-		assertThat(pc.getOutputLines().get(12), is("Hit count: 6"));
+		assertThat(pc.getOutputLines().get(12), startsWith("Hit count: "));
 	}
-	
+
 	@Test
-	public void searchMediumReactionTanimotoHas5Hits() {
+	public void searchMediumReactionTanimotoReturnsWithResult() {
 		ReactionSimilaritySearchExample.main(null);
-		assertThat(pc.getOutputLines().get(17), is("Hit count: 5"));
+		assertThat(pc.getOutputLines().get(17), startsWith("Hit count: "));
 	}
-	
+
 	@After
 	public void resetOutputStream() {
 		ReactionSimilaritySearchExample.out=System.out;
 	}
-	
+
 }

--- a/src/test/java/search/db/RetrievingDatabaseFieldsExampleTest.java
+++ b/src/test/java/search/db/RetrievingDatabaseFieldsExampleTest.java
@@ -24,10 +24,9 @@ public class RetrievingDatabaseFieldsExampleTest {
 	public void searchRetrievsFields() {
 		RetrievingDatabaseFieldsExample.main(null);
 		List<String> lines = pc.getOutputLines();
-		assertTrue("These messages should follow each other", followsEachOther(lines, "ID: 6", "Formula: C20H10Br2O5", "Mass: 490.103"));
 		assertEquals("These should be found twice", 2, count(lines, "ID: 6"));
 		assertEquals("These should be found twice", 2, count(lines, "Formula: C20H10Br2O5"));
-		assertEquals("These should be found twice", 2, count(lines, "Mass: 490.103"));
+		assertEquals("These should be found twice", 2, count(lines, "Mass: "));
 	}
 
 	@After
@@ -35,27 +34,14 @@ public class RetrievingDatabaseFieldsExampleTest {
 		RetrievingDatabaseFieldsExample.out = System.out;
 	}
 	
-
 	private int count(List<String> lines, String string) {
 		int count = 0;
 		for(String l: lines) {
-			if(l.equals(string)) {
+			if(l.contains(string)) {
 				++count;
 			}
 		}
 		return count;
-	}
-
-	private boolean followsEachOther(List<String> lines, String... strs) {
-		int previous = lines.indexOf(strs[0]);
-		for (int i = 1; i < strs.length; ++i) {
-			int idx = lines.indexOf(strs[i]);
-			if (idx < 1 || idx != previous + 1) {
-				return false;
-			}
-			previous = idx;
-		}
-		return previous > 0;
 	}
 
 }

--- a/src/test/java/search/db/SearchTypesExampleTest.java
+++ b/src/test/java/search/db/SearchTypesExampleTest.java
@@ -25,19 +25,18 @@ public class SearchTypesExampleTest {
 		SearchTypesExample.main(null);
 		List<String> lines = pc.getOutputLines();
 		//System.out.println(lines);
-		assertStartsWith(lines.get(0), "21 hit(s) found");
-		int expectedSimilarityHitCount = VersionInfo.getJChemTableVersion() >= 23050000 ? 7 : 6;
-		assertStartsWith(lines.get(1), expectedSimilarityHitCount+ " hit(s) found");
-		assertStartsWith(lines.get(2), "0 hit(s) found");
+		assertContains(lines.get(0), " hit(s) found");
+		assertContains(lines.get(1), " hit(s) found");
+		assertContains(lines.get(2), " hit(s) found");
 	}
 
-	private void assertStartsWith(String line, String prefix) {
-		assertTrue(line+" should start with "+prefix, line.startsWith(prefix));
+	private void assertContains(String line, String contained) {
+		assertTrue(line+" should contain "+contained, line.contains(contained));
 	}
 
 	@After
 	public void resetOutputStream() {
 		SearchTypesExample.out = System.out;
 	}
-	
+
 }

--- a/src/test/java/search/db/SearchWithFilterQueryExampleTest.java
+++ b/src/test/java/search/db/SearchWithFilterQueryExampleTest.java
@@ -3,6 +3,7 @@ package search.db;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
 
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,21 +13,21 @@ import com.chemaxon.test.helper.PrintCollector;
 public class SearchWithFilterQueryExampleTest {
 
 	private PrintCollector pc = new PrintCollector();
-	
+
 	@Before
 	public void changeOutputStream() {
 		SearchWithFilterQueryExample.out=pc.getOutStream();
 	}
-	
+
 	@Test
 	public void searchWithFilterQuery() {
 		SearchWithFilterQueryExample.main(null);
-		assertThat(pc.getOutputLines(), hasItem("Hit count: 21"));
+		assertThat(pc.getOutputLines(), hasItem(Matchers.containsString("Hit count: ")));
 	}
-	
+
 	@After
 	public void resetOutputStream() {
 		SearchWithFilterQueryExample.out=System.out;
 	}
-	
+
 }

--- a/src/test/java/search/db/SimilaritySearchExampleTest.java
+++ b/src/test/java/search/db/SimilaritySearchExampleTest.java
@@ -11,38 +11,38 @@ import com.chemaxon.test.helper.PrintCollector;
 
 public class SimilaritySearchExampleTest {
 	private PrintCollector pc = new PrintCollector();
-	
+
 	@Before
 	public void changeOutputStream() {
 		SimilaritySearchExample.out=pc.getOutStream();
 	}
-	
+
 	@Test
-	public void chemicalHashedFingerprintHas10Hits() {
+	public void chemicalHashedFingerprintReturnsWithResults() {
 		SimilaritySearchExample.main(null);
         assertThat(pc.getOutputLines().get(1), Matchers.is("Results using chemical hashed fingerprint:"));
-        assertThat(pc.getOutputLines().get(2), Matchers.is("Hit count: 10"));
+        assertThat(pc.getOutputLines().get(2), Matchers.startsWith("Hit count: "));
     }
 
     @Test
-    public void pharmacophoreHas130Hits() {
+    public void pharmacophoreReturnsWithResults() {
         SimilaritySearchExample.main(null);
         assertThat(pc.getOutputLines().get(5), Matchers.is("Results using descriptor: Pharmacophore"));
-        assertThat(pc.getOutputLines().get(6), Matchers.is("Hit count: 130"));
+        assertThat(pc.getOutputLines().get(6), Matchers.startsWith("Hit count: "));
     }
 
     @Test
-    public void hDonorHas382Hits() {
+    public void hDonorReturnsWithResults() {
         SimilaritySearchExample.main(null);
         assertThat(pc.getOutputLines().get(9), Matchers.is("Results using descriptor: HDonor"));
-        assertThat(pc.getOutputLines().get(10), Matchers.is("Hit count: 382"));
+        assertThat(pc.getOutputLines().get(10), Matchers.startsWith("Hit count: "));
     }
 
     @Test
-    public void hAcceptorHas382Hits() {
+    public void hAcceptorReturnsWithResults() {
         SimilaritySearchExample.main(null);
         assertThat(pc.getOutputLines().get(13), Matchers.is("Results using descriptor: HAcceptor"));
-        assertThat(pc.getOutputLines().get(14), Matchers.is("Hit count: 382"));
+        assertThat(pc.getOutputLines().get(14), Matchers.startsWith("Hit count: "));
     }
 
     @After


### PR DESCRIPTION
Chemical logic should be tested in the repository that contains it.